### PR TITLE
Mull is for C and C++, not for OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ As of now this repository is used to keep track of the current mutation testing 
 * JavaScript
   * https://github.com/lazywithclass/mutagen
   * https://github.com/stryker-mutator/stryker
-* OSX
+* C/C++
   * https://github.com/mull-project/mull
 * Php
   * https://github.com/humbug/humbug


### PR DESCRIPTION
Mull is built on top of LLVM. It works not only OS X, but also on Linux. Also, it could support any other LLVM based language: Rust, Swift, ObjC, etc.