### PR TITLE
update go-mutesting to active maintained fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Mutation testing is the practice of making better code by introducing bugs. As o
 * Erlang
   * [parsifal-47/muterl](https://github.com/parsifal-47/muterl)
 * Go
-  * [zimmski/go-mutesting](https://github.com/zimmski/go-mutesting)
+  * [jonbaldie/go-mutesting](https://github.com/jonbaldie/go-mutesting)
   * [Ooze](https://github.com/gtramontina/ooze)
   * [go-gremlins](https://github.com/go-gremlins/gremlins)
 * Haskell


### PR DESCRIPTION
The current entry points to [zimmski/go-mutesting](https://github.com/zimmski/go-mutesting), which last had a commit in June 2021.

[jonbaldie/go-mutesting](https://github.com/jonbaldie/go-mutesting) is the actively maintained continuation (forked via avito-tech) with an extended feature set:

- CI quality gates (`--min-msi`, `--min-covered-msi`) — fail the build below a mutation score threshold
- Coverage-aware MSI — scores covered and uncovered mutations separately
- Baseline file — tracks known-surviving mutants so CI only fails on *new* regressions
- Git-diff filtering (`--git-diff-lines`) — only mutates lines changed in a PR
- Parallel execution with `--workers`
- Per-test coverage map (`--per-test`) — runs only tests that cover each mutant
- Structured JSON, HTML, and LLM-ready agentic reports
- GitHub Actions annotation output
- Active release cadence with semver tags
- Documentation site: https://jonbaldie.github.io/go-mutesting/

This PR updates the URL and keeps the link text as `go-mutesting`. It was accepted onto [avelino/awesome-go](https://github.com/avelino/awesome-go/pull/6333) this week on the same basis.
