### PR TITLE
Add crucible (Python)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Mutation testing is the practice of making better code by introducing bugs. As o
 * Python
   * [sixty-north/cosmic-ray](https://github.com/sixty-north/cosmic-ray)
   * [boxed/mutmut](https://github.com/boxed/mutmut)
+  * [Jott2121/crucible](https://github.com/Jott2121/crucible) - adversarial test-hardening for AI-written code, built on mutmut
 * Ruby
   * [mbj/mutant](https://github.com/mbj/mutant)
     * [Kill all the mutants - a deep dive into mutation testing and how the Mutant gem works](https://troessner.svbtle.com/kill-all-the-mutants-a-deep-dive-into-mutation-testing-and-how-the-mutant-gem-works)


### PR DESCRIPTION
Adds [crucible](https://github.com/Jott2121/crucible) under Python, listed directly after mutmut because it is **built on** mutmut rather than being a competing engine.

**What it adds on top of mutmut:** it closes the loop. A Tester agent writes tests, mutmut names the surviving mutants, and a Critic agent is handed those *named* survivors and writes tests to kill exactly them. Every verdict stays mechanical — pytest kills the mutant or it doesn't — so no model ever grades model output.

The angle is AI-written code specifically: coverage measures what ran, not what would be caught, and that gap widens when a model writes both the code and its tests. On a real module with 7 passing tests and 97% line coverage, 25 of 71 injected defects survived.

- MIT, Python + pytest, mutmut pinned to 3.6.0
- The diagnose calls no model and needs no API key
- Dogfooded: runs its own mutation gate on itself (982 mutants, 977 killed, 5 documented survivors)
- Ships a GitHub Action that posts the mutation score on a PR
- Includes a pre-registered experiment, with the hypothesis that failed published alongside the one that held

If you'd rather it live somewhere other than the framework list (it is a tool on top of a framework, not a framework), just say and I'll move it.